### PR TITLE
Add ETag support

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,15 +1,23 @@
 var parse = require('url').parse;
+var etag = require('etag');
 
 var data = '<?xml version="1.0"?>' +
   '<!DOCTYPE cross-domain-policy SYSTEM "http://www.adobe.com/xml/dtds/cross-domain-policy.dtd">' +
   '<cross-domain-policy>' +
   '<site-control permitted-cross-domain-policies="none"/>' +
   '</cross-domain-policy>';
+var etagValue = etag(data, { weak: true });
 
 module.exports = function crossdomain(options) {
 
   options = options || {};
   var caseSensitive = options.caseSensitive;
+  var shouldSendEtag = (options.etag === undefined) ? true : options.etag;
+
+  var headers = { 'Content-Type': 'text/x-cross-domain-policy' };
+  if (shouldSendEtag) {
+    headers.ETag = etagValue;
+  }
 
   return function crossdomain(req, res, next) {
 
@@ -23,10 +31,13 @@ module.exports = function crossdomain(options) {
     }
 
     if ('/crossdomain.xml' === uri) {
-      res.writeHead(200, {
-        'Content-Type': 'text/x-cross-domain-policy'
-      });
-      res.end(data);
+      if (req.headers['if-none-match'] === etagValue) {
+        res.writeHead(304);
+        res.end();
+      } else {
+        res.writeHead(200, headers);
+        res.end(data);
+      }
     } else {
       next();
     }

--- a/package.json
+++ b/package.json
@@ -22,5 +22,8 @@
     "connect": "^3.3.2",
     "mocha": "^2.0.1",
     "supertest": "^0.15.0"
+  },
+  "dependencies": {
+    "etag": "^1.5.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,6 @@
   "devDependencies": {
     "connect": "^3.3.2",
     "mocha": "^2.0.1",
-    "supertest": "^0.14.0"
+    "supertest": "^0.15.0"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -81,6 +81,28 @@ describe('crossdomain', function () {
 
   });
 
+  it('sends an ETag header which is respected', function (done) {
+    request(app).get('/crossdomain.xml')
+    .expect(200, function (err, res) {
+      if (err) { return done(err); }
+      assert(res.headers.etag, 'ETag header is missing.');
+      request(app).get('/crossdomain.xml')
+      .set('If-None-Match', res.headers.etag)
+      .expect(304, done);
+    });
+  });
+
+  it('can disable ETags', function (done) {
+    app = connect();
+    app.use(crossdomain({ etag: false }));
+    request(app).get('/crossdomain.xml')
+    .expect(200, function (err, res) {
+      if (err) { return done(err); }
+      assert(!res.headers.etag, 'ETag header is present but should not be.');
+      done();
+    });
+  });
+
   it('names its function and middleware', function () {
     assert.equal(crossdomain.name, 'crossdomain');
     assert.equal(crossdomain().name, 'crossdomain');


### PR DESCRIPTION
I'd like someone else to look at this. Because it's _so_ non-urgent, I'm going to hope someone finds this.

This adds ETag support, which should improve performance, but it's pretty fringe. Only Adobe products will load *crossdomain.xml* and I'm not sure if they handle ETags at all, so this may be worthless.

Thoughts?