### PR TITLE
Add license to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "author": "Evan Hahn <me@evanhahn.com> (https://evanhahn.com)",
   "description": "Serve a restrictive crossdomain.xml at your site's root.",
   "version": "0.1.0",
+  "license": "MIT",
   "keywords": [
     "helmet",
     "security",


### PR DESCRIPTION
According to helmetjs/crossdomain#5 I added the MIT license in package.json